### PR TITLE
feat(core): concrete dependency impl when exposing sociable dependencies with injection tokens

### DIFF
--- a/packages/core/__test__/sociable/assets/injectable-registry.fixture.ts
+++ b/packages/core/__test__/sociable/assets/injectable-registry.fixture.ts
@@ -77,11 +77,17 @@ export class UserDigestService {
   }
 }
 
+export class DataMapper {
+  // Symbol.for() is typed as `unique symbol`, set a static ref to a "normal" symbol here for later use
+  static token = Symbol('DATA_MAPPER')
+}
+
 export class UserApiService {
   public constructor(
     private readonly userVerificationService: UserVerificationService,
     private readonly apiService: ApiService,
-    private readonly userDigestService: UserDigestService
+    private readonly userDigestService: UserDigestService,
+    @FakeInject(DataMapper.token) readonly dataMapper: DataMapper
   ) {}
 
   public async getUserData(userId: string): Promise<string> {

--- a/packages/core/__test__/sociable/sociable-testbed-builder.integration.test.ts
+++ b/packages/core/__test__/sociable/sociable-testbed-builder.integration.test.ts
@@ -2,9 +2,10 @@ import type { StubbedInstance } from '@suites/types.doubles';
 import { FakeAdapter } from './assets/integration.assets';
 import { mock } from './assets/mock.static';
 import type { Repository, User } from './assets/injectable-registry.fixture';
-import { Axios } from './assets/injectable-registry.fixture';
-import { HttpClient } from './assets/injectable-registry.fixture';
 import {
+  Axios,
+  DataMapper,
+  HttpClient,
   TestLogger,
   UserApiService,
   UserDal,
@@ -40,6 +41,7 @@ describe('Social TestBed Builder Integration Tests', () => {
       .expose(UserDal)
       .expose(HttpClient)
       .expose(DatabaseService)
+      .expose(Symbol.for('DATA_MAPPER'), DataMapper)
       .mock(TestLogger)
       .impl((stubFn: Mock) => ({ log: stubFn().mockReturnValue('overridden') }))
       .mock(Axios)
@@ -78,6 +80,7 @@ describe('Social TestBed Builder Integration Tests', () => {
     expect(() => unitRef.get(DatabaseService)).toThrowError();
     expect(() => unitRef.get(UserDal)).toThrowError();
     expect(() => unitRef.get(UserApiService)).toThrowError();
+    expect(() => unitRef.get(DataMapper)).toThrowError();
   });
 
   describe('creating a user with UserService', () => {

--- a/packages/core/src/services/builders/solitary-unit-builder.ts
+++ b/packages/core/src/services/builders/solitary-unit-builder.ts
@@ -40,7 +40,7 @@ export class SolitaryTestBedBuilder<TClass>
 
     const { container, instance, resolution } = await this.unitMocker.constructUnit<TClass>(
       this.targetClass,
-      [],
+      new Map(),
       new DependencyContainer([...identifiersToMocksImpls, ...identifiersToFinal])
     );
 
@@ -57,7 +57,7 @@ interactions. For detailed guidelines on setting up solitary tests, refer to: ht
 
     return {
       unit: instance as TClass,
-      unitRef: new UnitReference(container, [], this.identifiersToBeFinalized),
+      unitRef: new UnitReference(container, new Map(), this.identifiersToBeFinalized),
     };
   }
 }

--- a/packages/core/src/services/unit-mocker.spec.ts
+++ b/packages/core/src/services/unit-mocker.spec.ts
@@ -105,7 +105,7 @@ describe('Unit Mocker Unit Spec', () => {
 
       describe('when applying all the mocks on the target unit, including the already mocked', () => {
         beforeAll(async () => {
-          result = await underTest.constructUnit(DummyClass, [], mocksContainer);
+          result = await underTest.constructUnit(DummyClass, new Map(), mocksContainer);
         });
 
         it('should return container that lists all the dependencies together, mocked from the builder or from advanced', () => {

--- a/packages/core/src/services/unit-mocker.ts
+++ b/packages/core/src/services/unit-mocker.ts
@@ -1,5 +1,5 @@
 import type { MockFunction } from '@suites/types.doubles';
-import type { DependencyInjectionAdapter } from '@suites/types.di';
+import type { DependencyInjectionAdapter, InjectableIdentifier } from '@suites/types.di';
 import type { IdentifierToMockOrFinal } from './dependency-container';
 import { DependencyContainer } from './dependency-container';
 import type { Type } from '@suites/types.common';
@@ -11,7 +11,7 @@ export interface MockedUnit<TClass> {
   resolution: {
     notFound: IdentifierToMockOrFinal[];
     mocks: { metadata?: unknown; identifier: Type }[];
-    exposes: Type[];
+    exposes: InjectableIdentifier[];
   };
 }
 
@@ -23,7 +23,7 @@ export class UnitMocker {
 
   public async constructUnit<TClass>(
     targetClass: Type<TClass>,
-    classesToExpose: Type[],
+    classesToExpose: Map<InjectableIdentifier, Type>,
     mockContainer: DependencyContainer
   ): Promise<MockedUnit<TClass>> {
     const dependencyResolver = new DependencyResolver(

--- a/packages/core/src/services/unit-reference.spec.ts
+++ b/packages/core/src/services/unit-reference.spec.ts
@@ -40,7 +40,10 @@ describe('Unit Reference Unit Spec', () => {
 
     unitReference = new UnitReference(
       mocksContainer,
-      [RealDependencyOne, RealDependencyTwo],
+      new Map([
+        [RealDependencyOne, RealDependencyOne],
+        [RealDependencyTwo, RealDependencyTwo],
+      ]),
       fakedDependencies
     );
   });

--- a/packages/core/src/services/unit-reference.ts
+++ b/packages/core/src/services/unit-reference.ts
@@ -36,7 +36,7 @@ export interface UnitReference {
 export class UnitReference {
   public constructor(
     private readonly mocksContainer: DependencyContainer,
-    private readonly exposedInstances: InjectableIdentifier[],
+    private readonly exposedInstances: Map<InjectableIdentifier, Type>,
     private readonly fakedDependencies: IdentifierToFinal[]
   ) {}
 
@@ -78,7 +78,7 @@ Faked dependencies are not intended for direct retrieval and should be accessed 
 testing context or container. Refer to the docs for further information: https://suites.dev/docs`);
     }
 
-    if (typeof identifier === 'function' && this.exposedInstances.includes(identifier)) {
+    if (typeof identifier === 'function' && this.exposedInstances.has(identifier)) {
       throw new DependencyResolutionError(`The dependency associated with the specified identifier '${identifier.name}' could not be retrieved from the
 current testing context, as it is marked as an exposed dependency.
 Exposed dependencies are not intended for direct retrieval and should be accessed through the appropriate

--- a/packages/unit/src/types.ts
+++ b/packages/unit/src/types.ts
@@ -18,6 +18,7 @@ export interface SociableTestBedBuilder<TClass> extends SociableTestBedBuilderCo
    * @since 3.0.0
    * @template TClass The type of the class under test.
    * @param dependency The dependency to be exposed in its real or partially mocked state.
+   * @param concreteImplementation A concrete implementation to use if the dependency is a string or token identifier.
    * @returns A TestBedBuilder instance for further configuration.
    * @example
    * import { TestBed } from '@suites/unit';
@@ -29,6 +30,7 @@ export interface SociableTestBedBuilder<TClass> extends SociableTestBedBuilderCo
    * @param dependency
    */
   expose(dependency: Type): SociableTestBedBuilder<TClass>;
+  expose(dependency: symbol | string, concreteImplementation: Type): SociableTestBedBuilder<TClass>;
 }
 
 export interface SolitaryTestBedBuilder<TClass> extends TestBedBuilder<TClass> {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The pull request title follows the semantic commits guidelines: https://github.com/suites-dev/suites/blob/master/CONTRIBUTING.md#commit-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

1. `.sociable(ClassUnderTest).expose()`  does not accept string/symbol based dependency tokens
2. `.sociable(ClassUnderTest).expose(` does not expose concrete classes even if the parameter type is overidden as `never`

Issue Number: #464

## What is the new behavior?

* The `expose` method now accepts any `InjectableIdentifier` as the `dependency` and an optional `concreteImplementation: Type`
* `classesToExpose` is now a Map of `<Type | string | symbol, Type>` and is used to map the dependency identifier to a concrete value
* If the `dependency` is a class function (`Type`), use the dependency as both the identifier and the concrete value
    * Keeps backwards compatibility with previous behaviour
* Else, the `concreteImplementation` will be stored as the concrete value in the Map
* I've used method overloads to try and provide Intellisense/LSP hints that a `concreteImplementation` is required if the `dependency` is a symbol or string token
* This is all it takes for my [sample repository](https://github.com/craig0990/suites-sociable-inversify) from #464 to start passing

The rest of the changes are just to adapt to  `classesToExpose` now being a Map, and removing checks for exposed classes matching `typeof` "function"

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Completely understand if this doesn't get merged for any reason; simply wanted to offer a possible solution to the issue raised.