### PR TITLE
Remove lodash.isequal

### DIFF
--- a/packages/core/__test__/sociable-empty-constructor/assets/integration.assets.ts
+++ b/packages/core/__test__/sociable-empty-constructor/assets/integration.assets.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual } from 'node:util';
 import type {
   DependencyInjectionAdapter,
   ClassInjectable,
@@ -39,7 +39,7 @@ export const FakeAdapter: DependencyInjectionAdapter = {
             const subject = normalizeIdentifier(identifier, metadata as never);
             const toFind = normalizeIdentifier(injectable.identifier, injectable.metadata);
 
-            return isEqual(toFind, subject);
+            return isDeepStrictEqual(toFind, subject);
           });
       },
     };

--- a/packages/core/__test__/sociable/assets/integration.assets.ts
+++ b/packages/core/__test__/sociable/assets/integration.assets.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual } from 'node:util';
 import type {
   DependencyInjectionAdapter,
   ClassInjectable,
@@ -59,7 +59,7 @@ export const FakeAdapter: DependencyInjectionAdapter = {
             const subject = normalizeIdentifier(identifier, metadata as never);
             const toFind = normalizeIdentifier(injectable.identifier, injectable.metadata);
 
-            return isEqual(toFind, subject);
+            return isDeepStrictEqual(toFind, subject);
           });
       },
     };

--- a/packages/core/__test__/solitary/assets/integration.assets.ts
+++ b/packages/core/__test__/solitary/assets/integration.assets.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual } from 'node:util';
 import {
   DependencyInjectionAdapter,
   ClassInjectable,
@@ -177,7 +177,7 @@ export const FakeDIAdapter: DependencyInjectionAdapter = {
           const subject = normalizeIdentifier(identifier, metadata as never);
           const toFind = normalizeIdentifier(injectable.identifier, injectable.metadata);
 
-          return isEqual(toFind, subject);
+          return isDeepStrictEqual(toFind, subject);
         });
       },
     };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,12 +36,9 @@
   ],
   "dependencies": {
     "@suites/types.common": "^3.0.0",
-    "@suites/types.di": "^3.0.0",
-    "lodash.isequal": "^4.5.0"
+    "@suites/types.di": "^3.0.0"
   },
-  "devDependencies": {
-    "@types/lodash.isequal": "^4.5.6"
-  },
+  "devDependencies": {},
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/core/src/services/dependency-container.ts
+++ b/packages/core/src/services/dependency-container.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual } from 'node:util';
 import type { ClassInjectable, IdentifierMetadata, InjectableIdentifier } from '@suites/types.di';
 import type { Stub, StubbedInstance } from '@suites/types.doubles';
 import type { ConstantValue, DeepPartial, FinalValue } from '@suites/types.common';
@@ -48,7 +48,7 @@ export class DependencyContainer {
     // If there are more than one injectable with the same identifier, we need to check the metadata as well
     if (metadata) {
       const identifierToMock = identifiers.find(([{ metadata: injectableMetadata }]) =>
-        isEqual(injectableMetadata, metadata)
+        isDeepStrictEqual(injectableMetadata, metadata)
       );
 
       return identifierToMock

--- a/packages/core/src/services/unit-reference.ts
+++ b/packages/core/src/services/unit-reference.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual } from 'node:util';
 import type { StubbedInstance } from '@suites/types.doubles';
 import type { IdentifierMetadata, InjectableIdentifier } from '@suites/types.di';
 import type { Type } from '@suites/types.common';
@@ -68,7 +68,7 @@ export class UnitReference {
     if (
       this.fakedDependencies
         .map(([identifier]) => identifier)
-        .some((id) => isEqual(id, injectableIdentifier))
+        .some((id) => isDeepStrictEqual(id, injectableIdentifier))
     ) {
       const identifierString = stringifyIdentifier(identifier, identifierMetadata);
 

--- a/packages/di/inversify/package.json
+++ b/packages/di/inversify/package.json
@@ -35,15 +35,13 @@
   ],
   "dependencies": {
     "@suites/types.common": "^3.0.0",
-    "@suites/types.di": "^3.0.0",
-    "lodash.isequal": "^4.5.0"
+    "@suites/types.di": "^3.0.0"
   },
   "peerDependencies": {
     "inversify": ">= 6.0",
     "reflect-metadata": "<1.0.0"
   },
   "devDependencies": {
-    "@types/lodash.isequal": "^4.5.6",
     "inversify": "6.0.1",
     "reflect-metadata": "<1.0.0"
   },

--- a/packages/di/inversify/src/dependencies-adapter.ts
+++ b/packages/di/inversify/src/dependencies-adapter.ts
@@ -1,4 +1,4 @@
-import isEqual from 'lodash.isequal';
+import { isDeepStrictEqual } from 'node:util';
 import type { Type } from '@suites/types.common';
 import type {
   DependencyInjectionAdapter,
@@ -44,7 +44,7 @@ export function DependenciesAdapter(
 
         if (metadata) {
           return injectables.find(({ metadata: injectableMetadata }) =>
-            isEqual(injectableMetadata, metadata)
+            isDeepStrictEqual(injectableMetadata, metadata)
           );
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,13 +1539,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/lodash.isequal@^4.5.6":
-  version "4.5.8"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz#b30bb6ff6a5f6c19b3daf389d649ac7f7a250499"
-  integrity sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.13.tgz#786e2d67cfd95e32862143abe7463a7f90c300eb"
@@ -5642,11 +5635,6 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
Hi, `lodash.isequal` package warns that it is deprecated:
"This package is deprecated. Use require('node:util').isDeepStrictEqual instead."

As suites is used for testing backend (Node.js) applications - places where it was used can use `isDeepStrictEqual` from `node:util`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The pull request title follows the semantic commits guidelines: https://github.com/suites-dev/suites/blob/master/CONTRIBUTING.md#commit-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

It prints about `lodash.isequal` deprecation when I install your package

Issue Number: N/A

## What is the new behavior?

It should no longer bother me with `lodash.isequal` deprecation message

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I ran `yarn test` and `yarn lint` according to the CONTRIBUTING.md, let me know if there is something I missed
