### PR TITLE
fix(core): add missing @suites/types.doubles dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,10 +23,10 @@
     "node": ">= 20"
   },
   "scripts": {
-    "prebuild": "yarn rimraf dist",
-    "build": "yarn tsc -p tsconfig.build.json",
+    "prebuild": "pnpm rimraf dist",
+    "build": "pnpm tsc -p tsconfig.build.json",
     "test": "jest --coverage --verbose",
-    "lint": "yarn eslint '{src,test}/**/*.ts'"
+    "lint": "pnpm eslint '{src,test}/**/*.ts'"
   },
   "files": [
     "dist",
@@ -36,7 +36,8 @@
   ],
   "dependencies": {
     "@suites/types.common": "^3.0.0",
-    "@suites/types.di": "^3.0.0"
+    "@suites/types.di": "^3.0.0",
+    "@suites/types.doubles": "^3.0.0"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,10 +23,10 @@
     "node": ">= 20"
   },
   "scripts": {
-    "prebuild": "pnpm rimraf dist",
-    "build": "pnpm tsc -p tsconfig.build.json",
+    "prebuild": "yarn rimraf dist",
+    "build": "yarn tsc -p tsconfig.build.json",
     "test": "jest --coverage --verbose",
-    "lint": "pnpm eslint '{src,test}/**/*.ts'"
+    "lint": "yarn eslint '{src,test}/**/*.ts'"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Add types.doubles as a dependency to core.unit package. The package was already importing types from types.doubles but the dependency was not declared in package.json, causing build failures in environments where workspace linking is not available.